### PR TITLE
fix inter-tutorial linking

### DIFF
--- a/docs/src/tutorials/ActiveSampling.jl
+++ b/docs/src/tutorials/ActiveSampling.jl
@@ -1,4 +1,4 @@
-# # Active Sampling for Generative Designs
+# # [Active Sampling for Generative Designs](@id generative_designs_active)
 
 # ## Background on Active Sampling
 
@@ -22,7 +22,7 @@
 
 # This way, the sampled data will offer a more precise representation of the current state or trend.
 
-# For details on the theoretical background of generative designs and notation, please see our [introductory tutorial](SimpleGenerative.md) and an [applied tutorial](GenerativeDesigns.jl).
+# For details on the theoretical background of generative designs and notation, please see our [introductory tutorial](@ref simple_generative) and an [applied tutorial](@ref generative_designs).
 
 # Here we will again assume that the generative process is based on sampling from a historical dataset, which gives measurements on $m$ features $X = \{x_1, \ldots, x_m\}$ for $l$ entities
 # (with entities and features representing rows and columns, respectively). 
@@ -96,24 +96,25 @@ filter_range = Dict("x1" => (-1, 1), "x2" => (-1, 1))
 (sampler_active, uncertainty_active, weights_active) = DistanceBased(
     data;
     target = "y",
-    similarity = Exponential(; λ = 1),
+    similarity = Exponential(; λ = 0.5),
     filter_range = filter_range,
 );
 
 # To compare behavior with and without active sampling, we call `DistanceBased` again:
 (; sampler, uncertainty, weights) =
-    DistanceBased(data; target = "y", similarity = Exponential(; λ = 1));
+    DistanceBased(data; target = "y", similarity = Exponential(; λ = 0.5));
 
 # We plot the weights $w_j$ assigned to historical observations for both cases - with active sampling and without. The actual observation is shown in orange.
 evidence = Evidence("x1" => 5.0, "x2" => 0.5)
 #
 using Plots
-
-colors_active = max.(0.1, weights_active(evidence) ./ maximum(weights_active(evidence)))
+## The plotting engine (GR) requires us to use RGB instead of RGBA.
+rgba_to_rgb(a) = RGB(((1 - a) .* (1, 1, 1) .+ a .* (0.0, 0.5, 0.5))...)
+alphas_active = max.(0.1, weights_active(evidence) ./ maximum(weights_active(evidence)))
 p1 = scatter(
     data[!, "x1"],
     data[!, "x2"];
-    color = RGBA.(colorant"rgb(0,128,128)", colors_active),
+    color = map(a -> rgba_to_rgb(a), alphas_active),
     title = "weights\n(active sampling)",
     mscolor = nothing,
     colorbar = false,
@@ -129,11 +130,11 @@ scatter!(
 )
 p1
 #
-colors = max.(0.1, weights(evidence) ./ maximum(weights(evidence)))
+alphas = max.(0.1, weights(evidence) ./ maximum(weights(evidence)))
 p2 = scatter(
     data[!, "x1"],
     data[!, "x2"];
-    color = RGBA.(colorant"rgb(0,128,128)", colors),
+    color = map(a -> rgba_to_rgb(a), alphas),
     title = "weights\n(no active sampling)",
     mscolor = nothing,
     colorbar = false,

--- a/docs/src/tutorials/ActiveSampling.md
+++ b/docs/src/tutorials/ActiveSampling.md
@@ -2,7 +2,7 @@
 EditURL = "ActiveSampling.jl"
 ```
 
-# Active Sampling for Generative Designs
+# [Active Sampling for Generative Designs](@id generative_designs_active)
 
 ## Background on Active Sampling
 
@@ -26,7 +26,7 @@ active sampling can be used to assign more weight to recent data points or depri
 
 This way, the sampled data will offer a more precise representation of the current state or trend.
 
-For details on the theoretical background of generative designs and notation, please see our [introductory tutorial](SimpleGenerative.md) and an [applied tutorial](GenerativeDesigns.jl).
+For details on the theoretical background of generative designs and notation, please see our [introductory tutorial](@ref simple_generative) and an [applied tutorial](@ref generative_designs).
 
 Here we will again assume that the generative process is based on sampling from a historical dataset, which gives measurements on $m$ features $X = \{x_1, \ldots, x_m\}$ for $l$ entities
 (with entities and features representing rows and columns, respectively).
@@ -108,7 +108,7 @@ We then call `DistanceBased` as follows:
 (sampler_active, uncertainty_active, weights_active) = DistanceBased(
     data;
     target = "y",
-    similarity = Exponential(; λ = 1),
+    similarity = Exponential(; λ = 0.5),
     filter_range = filter_range,
 );
 nothing #hide
@@ -118,7 +118,7 @@ To compare behavior with and without active sampling, we call `DistanceBased` ag
 
 ````@example ActiveSampling
 (; sampler, uncertainty, weights) =
-    DistanceBased(data; target = "y", similarity = Exponential(; λ = 1));
+    DistanceBased(data; target = "y", similarity = Exponential(; λ = 0.5));
 nothing #hide
 ````
 
@@ -130,12 +130,13 @@ evidence = Evidence("x1" => 5.0, "x2" => 0.5)
 
 ````@example ActiveSampling
 using Plots
-
-colors_active = max.(0.1, weights_active(evidence) ./ maximum(weights_active(evidence)))
+# The plotting engine (GR) requires us to use RGB instead of RGBA.
+rgba_to_rgb(a) = RGB(((1 - a) .* (1, 1, 1) .+ a .* (0.0, 0.5, 0.5))...)
+alphas_active = max.(0.1, weights_active(evidence) ./ maximum(weights_active(evidence)))
 p1 = scatter(
     data[!, "x1"],
     data[!, "x2"];
-    color = RGBA.(colorant"rgb(0,128,128)", colors_active),
+    color = map(a -> rgba_to_rgb(a), alphas_active),
     title = "weights\n(active sampling)",
     mscolor = nothing,
     colorbar = false,
@@ -153,11 +154,11 @@ p1
 ````
 
 ````@example ActiveSampling
-colors = max.(0.1, weights(evidence) ./ maximum(weights(evidence)))
+alphas = max.(0.1, weights(evidence) ./ maximum(weights(evidence)))
 p2 = scatter(
     data[!, "x1"],
     data[!, "x2"];
-    color = RGBA.(colorant"rgb(0,128,128)", colors),
+    color = map(a -> rgba_to_rgb(a), alphas),
     title = "weights\n(no active sampling)",
     mscolor = nothing,
     colorbar = false,

--- a/docs/src/tutorials/GenerativeDesigns.jl
+++ b/docs/src/tutorials/GenerativeDesigns.jl
@@ -1,7 +1,7 @@
-# # Heart Disease Triage Meets Generative Modeling
+# # [Heart Disease Triage Meets Generative Modeling](@id generative_designs)
 
 # Consider again a situation where a group of patients is tested for a specific disease. It may be costly to conduct an experiment yielding the definitive answer; instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
-# For details on the theoretical background and notation, please see our tutorial on [generative experimental designs](SimpleGenerative.md). This tutorial
+# For details on the theoretical background and notation, please see our tutorial on [generative experimental designs](@ref simple_generative). This tutorial
 # is a concrete application of the tools described in that document.
 
 # Importantly, we aim to design personalized adaptive policies for each patient. At the beginning of the triage process, we use a patient's prior data, such as sex, age, or type of chest pain, to project a range of cost-efficient experimental designs. Internally, while constructing these designs, we incorporate multiple-step-ahead lookups to model probable experimental outcomes and consider the subsequent decisions for each outcome. Then after choosing a specific decision policy from this set and acquiring additional experimental readouts, we adjust the continuation based on this evidence.

--- a/docs/src/tutorials/GenerativeDesigns.md
+++ b/docs/src/tutorials/GenerativeDesigns.md
@@ -2,10 +2,10 @@
 EditURL = "GenerativeDesigns.jl"
 ```
 
-# Heart Disease Triage Meets Generative Modeling
+# [Heart Disease Triage Meets Generative Modeling](@id generative_designs)
 
 Consider again a situation where a group of patients is tested for a specific disease. It may be costly to conduct an experiment yielding the definitive answer; instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
-For details on the theoretical background and notation, please see our tutorial on [generative experimental designs](SimpleGenerative.md). This tutorial
+For details on the theoretical background and notation, please see our tutorial on [generative experimental designs](@ref simple_generative). This tutorial
 is a concrete application of the tools described in that document.
 
 Importantly, we aim to design personalized adaptive policies for each patient. At the beginning of the triage process, we use a patient's prior data, such as sex, age, or type of chest pain, to project a range of cost-efficient experimental designs. Internally, while constructing these designs, we incorporate multiple-step-ahead lookups to model probable experimental outcomes and consider the subsequent decisions for each outcome. Then after choosing a specific decision policy from this set and acquiring additional experimental readouts, we adjust the continuation based on this evidence.

--- a/docs/src/tutorials/SimpleGenerative.jl
+++ b/docs/src/tutorials/SimpleGenerative.jl
@@ -1,4 +1,4 @@
-# # Generative Experimental Designs
+# # [Generative Experimental Designs](@id simple_generative)
 
 # This document describes the theoretical background behind tools in CEEDesigns.jl for generative experimental designs
 # and demonstrates uses on synthetic data examples.
@@ -27,7 +27,7 @@
 # ### Historical Data
 
 # Like static designs, we consider a set $E$ of $n$ experiments, each with an associated tuple $(m_{e},t_{e})$ of monetary and
-# time costs (for more details on experiments and arrangements, see the tutorial on [static experimental designs](SimpleStatic.md)).
+# time costs (for more details on experiments and arrangements, see the tutorial on [static experimental designs](@ref simple_static)).
 # 
 # Additionally, consider a historical dataset giving measurements on $m$ features $X = \{x_1, \ldots, x_m\}$ for $l$ entities
 # (with entities and features representing rows and columns, respectively). Each experiment $e$ may yield measurements on some

--- a/docs/src/tutorials/SimpleGenerative.md
+++ b/docs/src/tutorials/SimpleGenerative.md
@@ -2,7 +2,7 @@
 EditURL = "SimpleGenerative.jl"
 ```
 
-# Generative Experimental Designs
+# [Generative Experimental Designs](@id simple_generative)
 
 This document describes the theoretical background behind tools in CEEDesigns.jl for generative experimental designs
 and demonstrates uses on synthetic data examples.
@@ -31,7 +31,7 @@ described below.
 ### Historical Data
 
 Like static designs, we consider a set $E$ of $n$ experiments, each with an associated tuple $(m_{e},t_{e})$ of monetary and
-time costs (for more details on experiments and arrangements, see the tutorial on [static experimental designs](SimpleStatic.md)).
+time costs (for more details on experiments and arrangements, see the tutorial on [static experimental designs](@ref simple_static)).
 
 Additionally, consider a historical dataset giving measurements on $m$ features $X = \{x_1, \ldots, x_m\}$ for $l$ entities
 (with entities and features representing rows and columns, respectively). Each experiment $e$ may yield measurements on some

--- a/docs/src/tutorials/SimpleStatic.jl
+++ b/docs/src/tutorials/SimpleStatic.jl
@@ -1,4 +1,4 @@
-# # Static Experimental Designs
+# # [Static Experimental Designs](@id simple_static)
 
 # In this document we describe the theoretical background behind the tools in CEEDesigns.jl for producing optimal "static experimental designs," i.e.,
 # arrangements of experiments that exist along a Pareto-optimal tradeoff between cost and information gain.
@@ -23,7 +23,7 @@
 # assume that for each experiment, future data will deterministically yield the same information gain as the "historical" data did.
 # This information gain from the "historical" data is quantified based on certain aggregate statistics.
 #
-# We can also consider "generative experimental designs," where the information gain is modeled as a random variable. This concept is detailed in another [tutorial](./SimpleGenerative.jl).
+# We can also consider "generative experimental designs," where the information gain is modeled as a random variable. This concept is detailed in another [tutorial](@ref simple_generative).
 # 
 # This tutorial introduces the theoretical framework behind static experimental designs with synthetic data.
 # For examples using real data, please see our other tutorials.

--- a/docs/src/tutorials/SimpleStatic.md
+++ b/docs/src/tutorials/SimpleStatic.md
@@ -2,7 +2,7 @@
 EditURL = "SimpleStatic.jl"
 ```
 
-# Static Experimental Designs
+# [Static Experimental Designs](@id simple_static)
 
 In this document we describe the theoretical background behind the tools in CEEDesigns.jl for producing optimal "static experimental designs," i.e.,
 arrangements of experiments that exist along a Pareto-optimal tradeoff between cost and information gain.
@@ -27,7 +27,7 @@ The arrangements produced by the tools introduced in this tutorial are called "s
 assume that for each experiment, future data will deterministically yield the same information gain as the "historical" data did.
 This information gain from the "historical" data is quantified based on certain aggregate statistics.
 
-We can also consider "generative experimental designs," where the information gain is modeled as a random variable. This concept is detailed in another [tutorial](./SimpleGenerative.jl).
+We can also consider "generative experimental designs," where the information gain is modeled as a random variable. This concept is detailed in another [tutorial](@ref simple_generative).
 
 This tutorial introduces the theoretical framework behind static experimental designs with synthetic data.
 For examples using real data, please see our other tutorials.

--- a/docs/src/tutorials/StaticDesigns.jl
+++ b/docs/src/tutorials/StaticDesigns.jl
@@ -1,12 +1,12 @@
-# # Heart Disease Triage
+# # [Heart Disease Triage](@id static_designs)
 
 # Consider a situation where a group of patients is tested for a specific disease. It may be costly to conduct an experiment yielding the definitive answer. Instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
-# For details on the theoretical background and notation, please see our tutorial on [static experimental designs](SimpleStatic.md), this tutorial
+# For details on the theoretical background and notation, please see our tutorial on [static experimental designs](@ref simple_static), this tutorial
 # is a concrete application of the tools described in that document.
 
 # ### Application to Predictive Modeling 
 
-# Let's generalize the example from [static experimental designs](SimpleStatic.md) to the case where we want to compute the information value $v_{S}$ as the predictive
+# Let's generalize the example from [static experimental designs](@ref simple_static) to the case where we want to compute the information value $v_{S}$ as the predictive
 # ability of a machine learning model which uses the measurements gained from experiments in $S$ to predict some $y$ of interest.
 # 
 # Let's introduce some formal notation.

--- a/docs/src/tutorials/StaticDesigns.md
+++ b/docs/src/tutorials/StaticDesigns.md
@@ -2,15 +2,15 @@
 EditURL = "StaticDesigns.jl"
 ```
 
-# Heart Disease Triage
+# [Heart Disease Triage](@id static_designs)
 
 Consider a situation where a group of patients is tested for a specific disease. It may be costly to conduct an experiment yielding the definitive answer. Instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
-For details on the theoretical background and notation, please see our tutorial on [static experimental designs](SimpleStatic.md), this tutorial
+For details on the theoretical background and notation, please see our tutorial on [static experimental designs](@ref simple_static), this tutorial
 is a concrete application of the tools described in that document.
 
 ### Application to Predictive Modeling
 
-Let's generalize the example from [static experimental designs](SimpleStatic.md) to the case where we want to compute the information value $v_{S}$ as the predictive
+Let's generalize the example from [static experimental designs](@ref simple_static) to the case where we want to compute the information value $v_{S}$ as the predictive
 ability of a machine learning model which uses the measurements gained from experiments in $S$ to predict some $y$ of interest.
 
 Let's introduce some formal notation.

--- a/docs/src/tutorials/StaticDesignsFiltration.jl
+++ b/docs/src/tutorials/StaticDesignsFiltration.jl
@@ -1,4 +1,4 @@
-# # Heart Disease Triage With Early Droupout
+# # [Heart Disease Triage With Early Droupout](@id static_designs_filtration)
 
 # Consider again a situation where a group of patients is tested for a specific disease. 
 # It may be costly to conduct an experiment yielding the definitive answer. Instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
@@ -7,7 +7,7 @@
 
 # ## Theoretical Framework
 
-# We take as a basis the setup and notation from the basic framework presented in the [static experimental designs tutorial](SimpleStatic.md).
+# We take as a basis the setup and notation from the basic framework presented in the [static experimental designs tutorial](@ref simple_static).
 
 # We again have a set of experiments $E$, but now assume that a set of extrinsic decision-making rules is imposed on the experimental readouts. 
 # If the experimental evidence acquired for a given entity satisfies a specific criterion, that entity is then removed from the triage. 

--- a/docs/src/tutorials/StaticDesignsFiltration.md
+++ b/docs/src/tutorials/StaticDesignsFiltration.md
@@ -2,7 +2,7 @@
 EditURL = "StaticDesignsFiltration.jl"
 ```
 
-# Heart Disease Triage With Early Droupout
+# [Heart Disease Triage With Early Droupout](@id static_designs_filtration)
 
 Consider again a situation where a group of patients is tested for a specific disease.
 It may be costly to conduct an experiment yielding the definitive answer. Instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
@@ -11,7 +11,7 @@ Moreover, we may assume that for some patients, the evidence gathered from proxy
 
 ## Theoretical Framework
 
-We take as a basis the setup and notation from the basic framework presented in the [static experimental designs tutorial](SimpleStatic.md).
+We take as a basis the setup and notation from the basic framework presented in the [static experimental designs tutorial](@ref simple_static).
 
 We again have a set of experiments $E$, but now assume that a set of extrinsic decision-making rules is imposed on the experimental readouts.
 If the experimental evidence acquired for a given entity satisfies a specific criterion, that entity is then removed from the triage.

--- a/tutorials/ActiveSampling.jl
+++ b/tutorials/ActiveSampling.jl
@@ -1,4 +1,4 @@
-# # Active Sampling for Generative Designs
+# # [Active Sampling for Generative Designs](@id generative_designs_active)
 
 # ## Background on Active Sampling
 
@@ -22,7 +22,7 @@
 
 # This way, the sampled data will offer a more precise representation of the current state or trend.
 
-# For details on the theoretical background of generative designs and notation, please see our [introductory tutorial](SimpleGenerative.md) and an [applied tutorial](GenerativeDesigns.jl).
+# For details on the theoretical background of generative designs and notation, please see our [introductory tutorial](@ref simple_generative) and an [applied tutorial](@ref generative_designs).
 
 # Here we will again assume that the generative process is based on sampling from a historical dataset, which gives measurements on $m$ features $X = \{x_1, \ldots, x_m\}$ for $l$ entities
 # (with entities and features representing rows and columns, respectively). 

--- a/tutorials/GenerativeDesigns.jl
+++ b/tutorials/GenerativeDesigns.jl
@@ -1,7 +1,7 @@
-# # Heart Disease Triage Meets Generative Modeling
+# # [Heart Disease Triage Meets Generative Modeling](@id generative_designs)
 
 # Consider again a situation where a group of patients is tested for a specific disease. It may be costly to conduct an experiment yielding the definitive answer; instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
-# For details on the theoretical background and notation, please see our tutorial on [generative experimental designs](SimpleGenerative.md). This tutorial
+# For details on the theoretical background and notation, please see our tutorial on [generative experimental designs](@ref simple_generative). This tutorial
 # is a concrete application of the tools described in that document.
 
 # Importantly, we aim to design personalized adaptive policies for each patient. At the beginning of the triage process, we use a patient's prior data, such as sex, age, or type of chest pain, to project a range of cost-efficient experimental designs. Internally, while constructing these designs, we incorporate multiple-step-ahead lookups to model probable experimental outcomes and consider the subsequent decisions for each outcome. Then after choosing a specific decision policy from this set and acquiring additional experimental readouts, we adjust the continuation based on this evidence.

--- a/tutorials/SimpleGenerative.jl
+++ b/tutorials/SimpleGenerative.jl
@@ -1,4 +1,4 @@
-# # Generative Experimental Designs
+# # [Generative Experimental Designs](@id simple_generative)
 
 # This document describes the theoretical background behind tools in CEEDesigns.jl for generative experimental designs
 # and demonstrates uses on synthetic data examples.
@@ -27,7 +27,7 @@
 # ### Historical Data
 
 # Like static designs, we consider a set $E$ of $n$ experiments, each with an associated tuple $(m_{e},t_{e})$ of monetary and
-# time costs (for more details on experiments and arrangements, see the tutorial on [static experimental designs](SimpleStatic.md)).
+# time costs (for more details on experiments and arrangements, see the tutorial on [static experimental designs](@ref simple_static)).
 # 
 # Additionally, consider a historical dataset giving measurements on $m$ features $X = \{x_1, \ldots, x_m\}$ for $l$ entities
 # (with entities and features representing rows and columns, respectively). Each experiment $e$ may yield measurements on some

--- a/tutorials/SimpleStatic.jl
+++ b/tutorials/SimpleStatic.jl
@@ -1,4 +1,4 @@
-# # Static Experimental Designs
+# # [Static Experimental Designs](@id simple_static)
 
 # In this document we describe the theoretical background behind the tools in CEEDesigns.jl for producing optimal "static experimental designs," i.e.,
 # arrangements of experiments that exist along a Pareto-optimal tradeoff between cost and information gain.
@@ -23,7 +23,7 @@
 # assume that for each experiment, future data will deterministically yield the same information gain as the "historical" data did.
 # This information gain from the "historical" data is quantified based on certain aggregate statistics.
 #
-# We can also consider "generative experimental designs," where the information gain is modeled as a random variable. This concept is detailed in another [tutorial](./SimpleGenerative.jl).
+# We can also consider "generative experimental designs," where the information gain is modeled as a random variable. This concept is detailed in another [tutorial](@ref simple_generative).
 # 
 # This tutorial introduces the theoretical framework behind static experimental designs with synthetic data.
 # For examples using real data, please see our other tutorials.

--- a/tutorials/StaticDesigns.jl
+++ b/tutorials/StaticDesigns.jl
@@ -1,12 +1,12 @@
-# # Heart Disease Triage
+# # [Heart Disease Triage](@id static_designs)
 
 # Consider a situation where a group of patients is tested for a specific disease. It may be costly to conduct an experiment yielding the definitive answer. Instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
-# For details on the theoretical background and notation, please see our tutorial on [static experimental designs](SimpleStatic.md), this tutorial
+# For details on the theoretical background and notation, please see our tutorial on [static experimental designs](@ref simple_static), this tutorial
 # is a concrete application of the tools described in that document.
 
 # ### Application to Predictive Modeling 
 
-# Let's generalize the example from [static experimental designs](SimpleStatic.md) to the case where we want to compute the information value $v_{S}$ as the predictive
+# Let's generalize the example from [static experimental designs](@ref simple_static) to the case where we want to compute the information value $v_{S}$ as the predictive
 # ability of a machine learning model which uses the measurements gained from experiments in $S$ to predict some $y$ of interest.
 # 
 # Let's introduce some formal notation.

--- a/tutorials/StaticDesignsFiltration.jl
+++ b/tutorials/StaticDesignsFiltration.jl
@@ -1,4 +1,4 @@
-# # Heart Disease Triage With Early Droupout
+# # [Heart Disease Triage With Early Droupout](@id static_designs_filtration)
 
 # Consider again a situation where a group of patients is tested for a specific disease. 
 # It may be costly to conduct an experiment yielding the definitive answer. Instead, we want to utilize various proxy experiments that provide partial information about the presence of the disease.
@@ -7,7 +7,7 @@
 
 # ## Theoretical Framework
 
-# We take as a basis the setup and notation from the basic framework presented in the [static experimental designs tutorial](SimpleStatic.md).
+# We take as a basis the setup and notation from the basic framework presented in the [static experimental designs tutorial](@ref simple_static).
 
 # We again have a set of experiments $E$, but now assume that a set of extrinsic decision-making rules is imposed on the experimental readouts. 
 # If the experimental evidence acquired for a given entity satisfies a specific criterion, that entity is then removed from the triage. 


### PR DESCRIPTION
There was some problems with broken links between the tutorial pages. This PR changes the tutorials so that all of them have a top-level `@id` reference and use `@ref` to more robustly link between them.